### PR TITLE
Added print_table_header function to print PHP info table header

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -13,6 +13,7 @@ use std::ffi::CString;
 extern {
     pub fn php_info_print_table_start();
     pub fn php_info_print_table_row(num_cols: c_int, ...) -> c_void;
+    pub fn php_info_print_table_header(num_cols: c_int, ...) -> c_void;
     pub fn php_info_print_table_end();
 }
 
@@ -27,6 +28,15 @@ pub fn print_table_row(key: &str, value: &str) {
     let v2 = CString::new(value).unwrap();
     unsafe {
         php_info_print_table_row(2, v1.as_ptr(), v2.as_ptr());
+    };
+}
+
+/// Print the header of the PHP info table.
+pub fn print_table_header(key: &str, value: &str) {
+    let v1 = CString::new(key).unwrap();
+    let v2 = CString::new(value).unwrap();
+    unsafe {
+        php_info_print_table_header(2, v1.as_ptr(), v2.as_ptr());
     };
 }
 


### PR DESCRIPTION
https://github.com/php/php-src/blob/master/ext/standard/info.c#L1111-L1146